### PR TITLE
Allow oss/jwt-auth package v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^8.0",
     "api-ecosystem-for-laravel/dingo-api": "^4.0",
-    "php-open-source-saver/jwt-auth": "^1.4",
+    "php-open-source-saver/jwt-auth": "^1.4|^2.0",
     "illuminate/support": "^9.0",
     "ramsey/uuid": "^4.3"
   },


### PR DESCRIPTION
v2 is almost entirely backwards compatible, the only thing is changes to it's service provider to support octane, which may cause issues if you have heavily customised it.