### PR TITLE
Log non displayed errors

### DIFF
--- a/src/APIBoilerplate.php
+++ b/src/APIBoilerplate.php
@@ -3,6 +3,7 @@
 namespace Specialtactics\L5Api;
 
 use Config;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class APIBoilerplate
@@ -13,6 +14,13 @@ class APIBoilerplate
     const CAMEL_CASE = 'camel-case';
     const SNAKE_CASE = 'snake-case';
     const DEFAULT_CASE = self::CAMEL_CASE;
+
+    /**
+     * The logger to be used by the boilerplate
+     *
+     * @var LoggerInterface $logger
+     */
+    protected static $logger;
 
     /**
      * Case type config path
@@ -135,5 +143,27 @@ class APIBoilerplate
     public static function formatKeyCaseAccordingToReponseFormat($value)
     {
         return self::formatCaseAccordingToResponseFormat($value);
+    }
+
+
+    /**
+     * Set a custom logger
+     *
+     * @param LoggerInterface $logger
+     * @return void
+     */
+    public static function setLogger(LoggerInterface $logger)
+    {
+        static::$logger = $logger;
+    }
+
+    /**
+     * Return the logger we are using
+     *
+     * @return LoggerInterface
+     */
+    public static function getLogger(): LoggerInterface
+    {
+        return static::$logger;
     }
 }

--- a/src/APIBoilerplate.php
+++ b/src/APIBoilerplate.php
@@ -145,11 +145,10 @@ class APIBoilerplate
         return self::formatCaseAccordingToResponseFormat($value);
     }
 
-
     /**
      * Set a custom logger
      *
-     * @param LoggerInterface $logger
+     * @param  LoggerInterface  $logger
      * @return void
      */
     public static function setLogger(LoggerInterface $logger)

--- a/src/L5ApiServiceProvider.php
+++ b/src/L5ApiServiceProvider.php
@@ -27,6 +27,9 @@ class L5ApiServiceProvider extends LaravelServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands(Console\Commands\MakeApiResource::class);
         }
+
+        // Set the logger instance to the laravel's default to begin with
+        APIBoilerplate::setLogger(\Log::getLogger());
     }
 
     /**

--- a/src/Services/RestfulService.php
+++ b/src/Services/RestfulService.php
@@ -2,6 +2,7 @@
 
 namespace Specialtactics\L5Api\Services;
 
+use Specialtactics\L5Api\APIBoilerplate;
 use Validator;
 use Config;
 use Illuminate\Http\Request;
@@ -87,16 +88,20 @@ class RestfulService
             if ($e instanceof QueryException) {
                 if (stristr($e->getMessage(), 'duplicate')) {
                     throw new ConflictHttpException('The resource already exists: ' . class_basename($model));
-                } elseif (Config::get('api.debug') === true) {
+                } elseif (config::get('api.debug') === true) {
                     throw $e;
+                } else {
+                    APIBoilerplate::getLogger()->debug($e->getMessage());
                 }
             }
 
             // Default HTTP exception to use for storage errors
             $errorMessage = 'Unexpected error trying to store this resource.';
 
-            if (Config::get('api.debug') === true) {
+            if (config::get('api.debug') === true) {
                 $errorMessage .= ' ' . $e->getMessage();
+            } else {
+                APIBoilerplate::getLogger()->debug($errorMessage . ' ' . $e->getMessage());
             }
 
             throw new UnprocessableEntityHttpException($errorMessage);
@@ -124,6 +129,8 @@ class RestfulService
                     throw new ConflictHttpException('The resource already exists: ' . class_basename($resource));
                 } elseif (Config::get('api.debug') === true) {
                     throw $e;
+                } else {
+                    APIBoilerplate::getLogger()->debug($e->getMessage());
                 }
             }
 
@@ -132,6 +139,8 @@ class RestfulService
 
             if (Config::get('api.debug') === true) {
                 $errorMessage .= ' ' . $e->getMessage();
+            } else {
+                APIBoilerplate::getLogger()->debug($errorMessage . ' ' . $e->getMessage());
             }
 
             throw new UnprocessableEntityHttpException($errorMessage);


### PR DESCRIPTION
For errors we do not wish to putput in the response when API debug is set to false, let's log them in laravel with debug level instead, just in case we need the underlying error message