### PR TITLE
Fix edge case bug with a null response code in auth gate response

### DIFF
--- a/src/Http/Controllers/Features/AuthorizesUserActionsOnModelsTrait.php
+++ b/src/Http/Controllers/Features/AuthorizesUserActionsOnModelsTrait.php
@@ -105,7 +105,8 @@ trait AuthorizesUserActionsOnModelsTrait
         // @var $response \Illuminate\Auth\Access\Response
         $response = app(Gate::class)->forUser($user)->inspect($ability, $arguments);
         if (! empty($response->message())) {
-            throw new HttpException($response->code(), $response->message());
+            $responseCode = $response->code() ?? 403;
+            throw new HttpException($responseCode, $response->message());
         }
 
         return false;


### PR DESCRIPTION
It's possible to have an auth gate response with a `null` code in some situations