### PR TITLE
improve transforming date fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         stability: [prefer-stable]
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3, 8.4]
         laravel: [10]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "api-ecosystem-for-laravel/dingo-api": "^4.1",
     "php-open-source-saver/jwt-auth": "^2.1",
     "illuminate/support": "^10.0",
-    "ramsey/uuid": "^4.3"
+    "ramsey/uuid": "^4.3",
+    "nesbot/carbon": "^2.0|^3.0"
   },
   "require-dev": {
     "ext-json": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,41 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
-    >
-    <testsuites>
-        <testsuite name="API Test Suite">
-            <directory suffix="Test.php">./test/tests</directory>
-            <exclude>./test/tests/TestCase.php</exclude>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="DB_CONNECTION" value="testing"/>
-        <env name="APP_ENV" value="testing"/>
-        <!-- Test App -->
-        <env name="APP_DEBUG" value="true"/>
-        <env name="APP_URL" value="http://localhost"/>
-        <env name="APP_KEY" value="CC58JtJ6QNRTnAr3tdwTw6qMuiK4nDTaozD8Uk3zQ0xuTc6VbW2DBek3cArbnZTx"/>
-        <env name="API_PREFIX" value="/"/>
-        <env name="JWT_SECRET" value="WrL8dp51k231ErDyUMgazU9KceL1RKXusu1U39YARuMbUWKuurPEtqGhEDCrUMoB"/>
-        <env name="JWT_TTL" value="7220"/>
-        <!-- Test App -->
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" bootstrap="vendor/autoload.php" colors="true" failOnRisky="true" failOnWarning="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="API Test Suite">
+      <directory suffix="Test.php">./test/tests</directory>
+      <exclude>./test/tests/TestCase.php</exclude>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="DB_CONNECTION" value="testing"/>
+    <env name="APP_ENV" value="testing"/>
+    <!-- Test App -->
+    <env name="APP_DEBUG" value="true"/>
+    <env name="API_DEBUG" value="true"/>
+    <env name="APP_URL" value="http://localhost"/>
+    <env name="APP_KEY" value="CC58JtJ6QNRTnAr3tdwTw6qMuiK4nDTaozD8Uk3zQ0xuTc6VbW2DBek3cArbnZTx"/>
+    <env name="API_PREFIX" value="/"/>
+    <env name="JWT_SECRET" value="WrL8dp51k231ErDyUMgazU9KceL1RKXusu1U39YARuMbUWKuurPEtqGhEDCrUMoB"/>
+    <env name="JWT_TTL" value="7220"/>
+    <!-- Test App -->
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/APIBoilerplate.php
+++ b/src/APIBoilerplate.php
@@ -124,6 +124,11 @@ class APIBoilerplate
         return $attributeString;
     }
 
+    public static function getRequestedKeyCaseFormat(): string
+    {
+        return self::$requestedKeyCaseFormat;
+    }
+
     /**
      * Format the provided key string into the required case response format
      *

--- a/src/Transformers/RestfulTransformer.php
+++ b/src/Transformers/RestfulTransformer.php
@@ -2,6 +2,8 @@
 
 namespace Specialtactics\L5Api\Transformers;
 
+use DateTimeInterface;
+use Carbon\Carbon;
 use League\Fractal\TransformerAbstract;
 use Specialtactics\L5Api\APIBoilerplate;
 use Specialtactics\L5Api\Models\RestfulModel;
@@ -9,6 +11,8 @@ use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class RestfulTransformer extends TransformerAbstract
 {
+    public const DATE_CAST_TYPES = ['date', 'datetime', 'immutable_date', 'immutable_datetime'];
+
     /**
      * @var RestfulModel The model to be transformed
      */
@@ -82,11 +86,19 @@ class RestfulTransformer extends TransformerAbstract
         }, ARRAY_FILTER_USE_KEY);
 
         /*
-         * Format all dates as Iso8601 strings, this includes the created_at and updated_at columns
+         * Format all dates as Iso8601 strings, this includes timestamped columns
          */
-        foreach ($model->getDates() as $dateColumn) {
+        foreach ($this->getModelDateFields($model) as $dateColumn) {
             if (! empty($model->$dateColumn) && ! in_array($dateColumn, $filterOutAttributes)) {
-                $transformed[$dateColumn] = $model->$dateColumn->toIso8601String();
+                if ($model->$dateColumn instanceof DateTimeInterface) {
+                    $transformed[$dateColumn] = Carbon::instance($model->$dateColumn)->toIso8601String();
+                } else {
+                    try {
+                        $transformed[$dateColumn] = Carbon::parse($model->$dateColumn)->toIso8601String();
+                    } catch (\Error $e) {
+                        $transformed[$dateColumn] = $model->$dateColumn;
+                    }
+                }
             }
         }
 
@@ -252,5 +264,25 @@ class RestfulTransformer extends TransformerAbstract
         }
 
         return $transformed;
+    }
+
+    protected function getModelDateFields(EloquentModel $model): array
+    {
+        $dateFields = [];
+
+        foreach ($model->getDates() as $dateColumn) {
+            $dateFields[] = $dateColumn;
+        }
+
+        // For previous versions of Eloquent, dates were stored as arrays
+        $dateFields = array_merge($model->dates, $dateFields);
+
+        foreach ($model->getCasts() as $field => $castType) {
+            if (in_array($castType, static::DATE_CAST_TYPES)) {
+                $dateFields[] = $field;
+            }
+        }
+
+        return array_unique($dateFields);
     }
 }

--- a/src/Transformers/RestfulTransformer.php
+++ b/src/Transformers/RestfulTransformer.php
@@ -275,7 +275,9 @@ class RestfulTransformer extends TransformerAbstract
         }
 
         // For previous versions of Eloquent, dates were stored as arrays
-        $dateFields = array_merge($model->dates, $dateFields);
+        if ($model->dates && is_array($model->dates)) {
+            $dateFields = array_merge($model->dates, $dateFields);
+        }
 
         foreach ($model->getCasts() as $field => $castType) {
             if (in_array($castType, static::DATE_CAST_TYPES)) {

--- a/test/app/Models/Dates/ModelWithDates.php
+++ b/test/app/Models/Dates/ModelWithDates.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models\Dates;
+
+use App\Models\BaseModel;
+use App\Transformers\BaseTransformer;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ModelWithDates extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string UUID key
+     */
+    public $primaryKey = 'model_with_dates_id';
+
+    /**
+     * @var array The attributes that are mass assignable.
+     */
+    protected $fillable = ['title', 'processed_at', 'scheduled_at', 'counted_at'];
+
+    public $dates = ['created_at', 'updated_at', 'deleted_at', 'processed_at'];
+
+    public $casts = [
+        'scheduled_at' => 'date',
+        'counted_at' => 'datetime',
+    ];
+
+    /**
+     * Return the validation rules for this model
+     *
+     * @return array Rules
+     */
+    public function getValidationRules()
+    {
+        return [
+            'title' => 'required|string|unique:forums',
+        ];
+    }
+}

--- a/test/database/migrations/2024_12_06_000000_create_test_model_with_dates_table.php
+++ b/test/database/migrations/2024_12_06_000000_create_test_model_with_dates_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTestModelWithDatesTable extends Migration
+{
+
+    const TABLE_NAME = 'model_with_dates';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create(static::TABLE_NAME, function (Blueprint $table) {
+            $table->uuid('model_with_dates_id')->primary();
+            $table->string('title');
+
+            $table->timestamp('processed_at')->nullable();
+            $table->date('scheduled_at')->nullable();
+            $table->dateTime('counted_at')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists(static::TABLE_NAME);
+    }
+}

--- a/test/tests/Unit/JsonFormatterTest.php
+++ b/test/tests/Unit/JsonFormatterTest.php
@@ -16,6 +16,8 @@ class JsonFormatterTest extends AppTestCase
      */
     public function formatMetaArrayKeysAccordingToFormat()
     {
+        $originalCase = APIBoilerplate::getRequestedKeyCaseFormat();
+
         $jsonFormatter = new Json;
 
         // Camel
@@ -53,5 +55,8 @@ class JsonFormatterTest extends AppTestCase
         $responseData = $response->decodeResponseJson();
 
         $this->assertArrayHasKey('per_page', $responseData['meta']['pagination']);
+
+        // Restore to original
+        $this->setAPIKeyCase($originalCase);
     }
 }

--- a/test/tests/Unit/Transformation/DateTransformationTest.php
+++ b/test/tests/Unit/Transformation/DateTransformationTest.php
@@ -21,9 +21,6 @@ class DateTransformationTest extends AppTestCase
 
         $transformed = (new RestfulTransformer)->transform($model);
 
-        dump($transformed); // For github ci
-        dump(APIBoilerplate::getResponseCaseType());
-
         $this->assertTrue($this->doesMatchFormat($transformed['processedAt']));
         $this->assertTrue($this->doesMatchFormat($transformed['scheduledAt']));
         $this->assertTrue($this->doesMatchFormat($transformed['countedAt']));

--- a/test/tests/Unit/Transformation/DateTransformationTest.php
+++ b/test/tests/Unit/Transformation/DateTransformationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Specialtactics\L5Api\Tests\Unit;
+
+use App\Models\Dates\ModelWithDates;
+use Specialtactics\L5Api\Tests\AppTestCase;
+use Specialtactics\L5Api\Transformers\RestfulTransformer;
+
+class DateTransformationTest extends AppTestCase
+{
+    /**
+    * Check various dates are formatted correctly
+     *
+     * @test
+     */
+    public function canTransformDates()
+    {
+        $model = new ModelWithDates(['title' => 'Example dates', 'processed_at' => now(), 'scheduled_at' => now()->addDays(10), 'counted_at' => now()->subDays(5)]);
+        $model->save();
+
+        $transformed = (new RestfulTransformer)->transform($model);
+
+        $this->assertTrue($this->doesMatchFormat($transformed['processedAt']));
+        $this->assertTrue($this->doesMatchFormat($transformed['scheduledAt']));
+        $this->assertTrue($this->doesMatchFormat($transformed['countedAt']));
+        $this->assertTrue($this->doesMatchFormat($transformed['createdAt']));
+        $this->assertTrue($this->doesMatchFormat($transformed['updatedAt']));
+
+
+        $this->assertEquals('Example dates', $transformed['title']);
+    }
+
+    protected function doesMatchFormat(string $date): bool
+    {
+        return preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z/', $date) === 1;
+    }
+}

--- a/test/tests/Unit/Transformation/DateTransformationTest.php
+++ b/test/tests/Unit/Transformation/DateTransformationTest.php
@@ -20,6 +20,8 @@ class DateTransformationTest extends AppTestCase
 
         $transformed = (new RestfulTransformer)->transform($model);
 
+        dump($transformed); // For github ci
+
         $this->assertTrue($this->doesMatchFormat($transformed['processedAt']));
         $this->assertTrue($this->doesMatchFormat($transformed['scheduledAt']));
         $this->assertTrue($this->doesMatchFormat($transformed['countedAt']));

--- a/test/tests/Unit/Transformation/DateTransformationTest.php
+++ b/test/tests/Unit/Transformation/DateTransformationTest.php
@@ -3,6 +3,7 @@
 namespace Specialtactics\L5Api\Tests\Unit;
 
 use App\Models\Dates\ModelWithDates;
+use Specialtactics\L5Api\APIBoilerplate;
 use Specialtactics\L5Api\Tests\AppTestCase;
 use Specialtactics\L5Api\Transformers\RestfulTransformer;
 
@@ -21,6 +22,7 @@ class DateTransformationTest extends AppTestCase
         $transformed = (new RestfulTransformer)->transform($model);
 
         dump($transformed); // For github ci
+        dump(APIBoilerplate::getResponseCaseType());
 
         $this->assertTrue($this->doesMatchFormat($transformed['processedAt']));
         $this->assertTrue($this->doesMatchFormat($transformed['scheduledAt']));


### PR DESCRIPTION
Adds a bunch of testing around transformation of dates
Combined the new casts and older dates functionality for backwards compatibility
Adds more PHP versions in CI

Also making date transformation more robust (I haven't seen any issues, but just in case), and switching to the `toISOString` which is the same as `toJSON` that Laravel uses, but while keeping timezone information, if the developer wants to use a non-UTC timezone as app timezone.